### PR TITLE
check slaveid collisions only by slaveid-port

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-device-manager (1.0.0) stable; urgency=medium
+
+  * Public release:
+  *   - remove serial_params from slaveid-collisions check
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 26 Dec 2022 14:18:21 +0300
+
 wb-device-manager (0.1.0) stable; urgency=medium
 
   * Initial release:

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -168,7 +168,8 @@ class DeviceManager():
             try:
                 if isinstance(event, DeviceInfo):
                     state.devices.append(event)
-                    neighbors = devices_by_connection_params[str((event.cfg, event.port))]
+                    # wb-mqtt-serial treats devices with equal slaveid-port as same (even with different serial_params)
+                    neighbors = devices_by_connection_params[str((event.cfg.slave_id, event.port))]
                     neighbors.append(event)
                     if len(neighbors) > 1:
                         for entry in neighbors:


### PR DESCRIPTION
убрал serial-настроечки из проверки коллизий slaveid (как обсуждали на демке)

![2022-12-26_16-32-56](https://user-images.githubusercontent.com/25829054/209554334-02a988cb-46d7-4cfe-adc7-ae82729c3476.png)
