### PR TITLE
rpc-call: reduce frame_timeout from default 20ms to 3.5 modbus chars

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.0.1) stable; urgency=medium
+
+  * rpc-call to wb-mqtt-serial: reduce frame_timeout to 3.5 modbus chars
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 28 Dec 2022 00:16:38 +0300
+
 wb-device-manager (1.0.0) stable; urgency=medium
 
   * Public release:

--- a/tests/serial_bus_test.py
+++ b/tests/serial_bus_test.py
@@ -44,9 +44,9 @@ class TestMBExtendedScanner(unittest.IsolatedAsyncioTestCase):
 
     def test_arbitration_timeout_calculation(self):
         bds = [1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]
-        timeouts_ms = {bd: minimalmodbus._calculate_minimum_silent_period(bd) for bd in bds}
+        timeouts = {bd: minimalmodbus._calculate_minimum_silent_period(bd) for bd in bds}
 
-        for bd, assumed_timeout in timeouts_ms.items():
+        for bd, assumed_timeout in timeouts.items():
             self.assertEqual(self.scanner._get_arbitration_timeout(bd), assumed_timeout)
 
     async def test_correct_response(self):

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -84,7 +84,7 @@ class WBExtendedModbusScanner:
                 )
 
     def _get_arbitration_timeout(self, bd):
-        return minimalmodbus._calculate_minimum_silent_period(bd)
+        return self.instrument.calculate_minimum_silent_period_s(bd)
 
     async def _communicate(
         self,


### PR DESCRIPTION
по мотивам ускорения, вместо дефолтных 20мс frame_timeout стал 3.5 modbus chars