### PR TITLE
fix response parsing on some corner serial_number cases

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.1.2) stable; urgency=medium
+
+  * Fix response parsing on some corner serial_number cases
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 18 Jan 2023 23:58:45 +0300
+
 wb-device-manager (1.1.1) stable; urgency=medium
 
   * Code formatting

--- a/tests/serial_bus_test.py
+++ b/tests/serial_bus_test.py
@@ -47,6 +47,7 @@ class TestMBExtendedScanner(unittest.IsolatedAsyncioTestCase):
         mocks = [
             ("fffffffffffffffffd6003fe34359603f6a80000000000000000", "FE34359603"),
             ("fffffffffffffffffd600300019424c7f4610000000000000000", "00019424C7"),
+            ("fffffffffffffffffd6003fed2efd601501a0000000000000000", "FED2EFD601"),
         ]
         for (mock, assumed_response) in mocks:
             self.mock_response(mock)

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -67,7 +67,7 @@ class WBExtendedModbusScanner:
         Typical plain_response_str looks like: ffffffff<response>00000000
         """
         mat = re.match(
-            "^.*(FF)*(?P<header>%X%X)(?P<cmd>[0-9A-F][0-9A-F]).+"
+            "^.*?(?P<header>%X%X)(?P<cmd>[0-9A-F][0-9A-F]).+"
             % (self.extended_modbus_wrapper.ADDR, self.extended_modbus_wrapper.MODE),
             plain_response_str,
         )


### PR DESCRIPTION
Илья нашел интересный краевой случай с определённым серийником (жадный regexp всё портил)