### PR TITLE
Bugfix/mge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.1.3) stable; urgency=medium
+
+  * Fix error on non-serial ports in get_ports response
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 19 Jan 2023 19:50:41 +0300
+
 wb-device-manager (1.1.2) stable; urgency=medium
 
   * Fix response parsing on some corner serial_number cases

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -41,10 +41,7 @@ class TestRPCClient(unittest.IsolatedAsyncioTestCase):
                 "path": "/dev/ttyRS485-2",
                 "stop_bits": 2,
             },
-            {
-                "address": "192.168.0.7",
-                "port": 23
-            },
+            {"address": "192.168.0.7", "port": 23},
         ]
         assumed_response = ["/dev/ttyRS485-1", "/dev/ttyRS485-2"]
         self.mock_response(response)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import AsyncMock
+
+from wb.device_manager import main
+
+
+class DummyDeviceManager(main.DeviceManager):
+    def __init__(self):
+        self._mqtt_connection = AsyncMock()
+        self._rpc_client = AsyncMock()
+        self._state_update_queue = AsyncMock()
+        self._asyncio_loop = AsyncMock()
+        self._is_scanning = False
+
+
+class TestRPCClient(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device_manager = DummyDeviceManager()
+
+    @classmethod
+    def mock_response(cls, response):
+        cls.device_manager.rpc_client.make_rpc_call = AsyncMock(return_value=response)
+
+    async def test_ports_acquiring(self):
+        response = [
+            {
+                "baud_rate": 9600,
+                "data_bits": 8,
+                "parity": "N",
+                "path": "/dev/ttyRS485-1",
+                "stop_bits": 2,
+            },
+            {
+                "baud_rate": 9600,
+                "data_bits": 8,
+                "parity": "N",
+                "path": "/dev/ttyRS485-2",
+                "stop_bits": 2,
+            },
+            {
+                "address": "192.168.0.7",
+                "port": 23
+            },
+        ]
+        assumed_response = ["/dev/ttyRS485-1", "/dev/ttyRS485-2"]
+        self.mock_response(response)
+        ret = await self.device_manager._get_ports()
+        self.assertListEqual(list(ret), assumed_response)

--- a/tests/serial_bus_test.py
+++ b/tests/serial_bus_test.py
@@ -48,6 +48,7 @@ class TestMBExtendedScanner(unittest.IsolatedAsyncioTestCase):
             ("fffffffffffffffffd6003fe34359603f6a80000000000000000", "FE34359603"),
             ("fffffffffffffffffd600300019424c7f4610000000000000000", "00019424C7"),
             ("fffffffffffffffffd6003fed2efd601501a0000000000000000", "FED2EFD601"),
+            ("fffffffffffffffffd60033938169d38f7000000000000000000", "3938169D38"),  # crc ends with zeroes
         ]
         for (mock, assumed_response) in mocks:
             self.mock_response(mock)

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -247,7 +247,8 @@ class DeviceManager:
             params={},
             timeout=1.0,  # s; rpc call goes around scheduler queue => relatively small
         )
-        return [port["path"] for port in response]
+        ports = [port.get("path") for port in response]
+        return filter(None, ports)
 
     async def launch_scan(self):
         if self._is_scanning:  # TODO: store mqtt topics and binded launched tasks (instead of launcher-cb)


### PR DESCRIPTION
девайс_менеджер падал у клиента при настроенном wb-mge
причина - отсутствие поля "path" в представлении у сериала при этом


и вспомнил-добавил тест-кейс с crc, заканчивающейся 0 (когда-то были проблемы, кажется)