### PR TITLE
Fix scanning devices with old firmware using 2 stopbits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### Build artifacts ###
+*.deb
+
 ### VisualStudioCode ###
 .vscode/*
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.5.3) stable; urgency=medium
+
+  * Fix scanning devices with old firmware using 2 stopbits
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 09 Feb 2023 16:17:00 +0400
+
 wb-device-manager (1.5.2) stable; urgency=medium
 
   * Fix corner-case, when "Stop" button not always stops all port-scan tasks

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -134,7 +134,7 @@ class TestDeviceManager(unittest.TestCase):
             "2400-O1",
             "4800-O1",
             "19200-O1",
-            "38400-O1"
+            "38400-O1",
         ]
         for bd, parity, stopbits, progress_percent in self.device_manager._get_all_uart_params():
             self.assertEqual(f"{bd}-{parity}{stopbits}", assumed_order.pop(0))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -49,7 +49,7 @@ class TestRPCClient(unittest.IsolatedAsyncioTestCase):
         assumed_response = ["/dev/ttyRS485-1", "/dev/ttyRS485-2"]
         self.mock_response(response)
         ret = await self.device_manager._get_ports()
-        self.assertListEqual(list(ret), assumed_response)
+        self.assertListEqual(ret, assumed_response)
 
 
 class TestExternalDeviceErrors(unittest.IsolatedAsyncioTestCase):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -79,3 +79,62 @@ class TestExternalDeviceErrors(unittest.IsolatedAsyncioTestCase):
         ]
         ret = await self.device_manager.fill_device_info(self.device_info, self.mb_conn)
         self.assertListEqual(ret, assumed_errors)
+
+
+class TestDeviceManager(unittest.TestCase):
+    def setUp(self):
+        self.device_manager = DummyDeviceManager()
+
+    def test_get_all_uart_params(self):
+        assumed_order = [
+            "115200-N2",
+            "9600-N2",
+            "57600-N2",
+            "115200-N1",
+            "9600-N1",
+            "57600-N1",
+            "1200-N2",
+            "2400-N2",
+            "4800-N2",
+            "19200-N2",
+            "38400-N2",
+            "1200-N1",
+            "2400-N1",
+            "4800-N1",
+            "19200-N1",
+            "38400-N1",
+            "115200-E2",
+            "9600-E2",
+            "57600-E2",
+            "115200-E1",
+            "9600-E1",
+            "57600-E1",
+            "1200-E2",
+            "2400-E2",
+            "4800-E2",
+            "19200-E2",
+            "38400-E2",
+            "1200-E1",
+            "2400-E1",
+            "4800-E1",
+            "19200-E1",
+            "38400-E1",
+            "115200-O2",
+            "9600-O2",
+            "57600-O2",
+            "115200-O1",
+            "9600-O1",
+            "57600-O1",
+            "1200-O2",
+            "2400-O2",
+            "4800-O2",
+            "19200-O2",
+            "38400-O2",
+            "1200-O1",
+            "2400-O1",
+            "4800-O1",
+            "19200-O1",
+            "38400-O1"
+        ]
+        for bd, parity, stopbits, progress_percent in self.device_manager._get_all_uart_params():
+            self.assertEqual(f"{bd}-{parity}{stopbits}", assumed_order.pop(0))

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -308,13 +308,14 @@ class DeviceManager:
     ):
         len_iterable = len(bds) * len(parities) * len(stopbits)
         pos = 0
+        most_frequent_bds, less_frequent_bds = bds[:3], bds[3:]
         for parity in parities:
             for stopbit in stopbits:
-                for bd in bds[:3]:
+                for bd in most_frequent_bds:
                     pos += 1
                     yield bd, parity, stopbit, int(pos / len_iterable * 100)
             for stopbit in stopbits:
-                for bd in bds[3:]:
+                for bd in less_frequent_bds:
                     pos += 1
                     yield bd, parity, stopbit, int(pos / len_iterable * 100)
 

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -404,7 +404,13 @@ class DeviceManager:
             modbus_scanner = serial_bus.WBModbusScanner(port, self.rpc_client)
 
         # new firmwares can work with any stopbits, but old ones can't
-        allowed_stopbits = stopbits=[2,] if is_ext_scan else [2, 1]
+        allowed_stopbits = stopbits = (
+            [
+                2,
+            ]
+            if is_ext_scan
+            else [2, 1]
+        )
 
         for bd, parity, stopbits, progress_percent in self._get_all_uart_params(stopbits=allowed_stopbits):
             debug_str = "%s %d %d%s%d" % (port, bd, 8, parity, stopbits)

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -303,7 +303,7 @@ class DeviceManager:
     def _get_all_uart_params(
         self,
         bds=[115200, 9600, 57600, 1200, 2400, 4800, 19200, 38400],
-        parities=["N", "O", "E"],
+        parities=["N", "E", "O"],
         stopbits=[2, 1],
     ):
         len_iterable = len(bds) * len(parities) * len(stopbits)

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -409,8 +409,9 @@ class DeviceManager:
         else:
             modbus_scanner = serial_bus.WBModbusScanner(port, self.rpc_client)
 
-        # new firmwares can work with any stopbits, but old ones can't
-        allowed_stopbits = stopbits = (
+        # New firmwares can work with any stopbits, but old ones can't
+        # Since it doesn't matter what to use, let's use 2
+        allowed_stopbits = (
             [
                 2,
             ]

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -306,6 +306,11 @@ class DeviceManager:
         parities=["N", "E", "O"],
         stopbits=[2, 1],
     ):
+        """There are the following assumptions:
+        1. Most frequently used baudrates are 115200, 9600, 57600
+        2. Most frequently used parity is "N"
+        So, yield them first, then yield less frequently used baudrates and parities
+        """
         len_iterable = len(bds) * len(parities) * len(stopbits)
         pos = 0
         most_frequent_bds, less_frequent_bds = bds[:3], bds[3:]


### PR DESCRIPTION
Поправил порядок сканирования, теперь такой:
```
115200 8N2
9600 8N2
57600 8N2
115200 8N1
9600 8N1
57600 8N1
1200 8N2
2400 8N2
4800 8N2
19200 8N2
38400 8N2
1200 8N1
2400 8N1
4800 8N1
19200 8N1
38400 8N1
115200 8O2
9600 8O2
57600 8O2
115200 8O1
9600 8O1
57600 8O1
1200 8O2
2400 8O2
4800 8O2
19200 8O2
38400 8O2
1200 8O1
2400 8O1
4800 8O1
19200 8O1
38400 8O1
115200 8E2
9600 8E2
57600 8E2
115200 8E1
9600 8E1
57600 8E1
1200 8E2
2400 8E2
4800 8E2
19200 8E2
38400 8E2
1200 8E1
2400 8E1
4800 8E1
19200 8E1
38400 8E1
```