### PR TITLE
Use mqtt client wrapper from wb-common

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.5.4) stable; urgency=medium
+
+  * Use mqtt client wrapper from wb-common
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 18:39:00 +0400
+
 wb-device-manager (1.5.3) stable; urgency=medium
 
   * Fix scanning devices with old firmware using 2 stopbits

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,6 @@ Architecture: all
 Breaks: python3-wb-device-manager
 Replaces: python3-wb-device-manager
 Provides: python3-wb-device-manager
-Depends: ${python3:Depends}, ${misc:Depends}, python3-mqttrpc (>= 1.1.5), wb-mqtt-serial (>= 2.77.6), python3-wb-mcu-fw-updater (>= 1.6.1)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.5), wb-mqtt-serial (>= 2.77.6), python3-wb-mcu-fw-updater (>= 1.6.1)
 Recommends: wb-mqtt-homeui (>= 2.50.0)
 Description: Wiren Board modbus devices manager (python3 service; backend)

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
 Section: python
 Priority: optional
 XS-Python-Version: >= 3.9.1
-Build-Depends: dh-python, debhelper (>= 10), python3-all, python3-setuptools, python3-wb-common (>= 2.1.0), python3-wb-mcu-fw-updater, python3-mqttrpc (>= 1.1.5)
+Build-Depends: dh-python, debhelper (>= 10), python3-all, python3-setuptools, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-wb-mcu-fw-updater, python3-mqttrpc (>= 1.1.5)
 Standards-Version: 3.9.1
 X-Python-Version: >= 3.9.1
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
 Section: python
 Priority: optional
 XS-Python-Version: >= 3.9.1
-Build-Depends: dh-python, debhelper (>= 10), python3-all, python3-setuptools, python3-paho-mqtt, python3-paho-socket, python3-wb-mcu-fw-updater, python3-mqttrpc (>= 1.1.5)
+Build-Depends: dh-python, debhelper (>= 10), python3-all, python3-setuptools, python3-wb-common (>= 2.1.0), python3-wb-mcu-fw-updater, python3-mqttrpc (>= 1.1.5)
 Standards-Version: 3.9.1
 X-Python-Version: >= 3.9.1
 

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -481,6 +481,7 @@ def main(args=argv):
     parser.add_argument(
         "-b",
         "--broker",
+        "--broker_url",
         dest="broker_url",
         type=str,
         help="MQTT broker url",

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -4,18 +4,15 @@
 import asyncio
 import json
 import logging
-import os
 import time
 import uuid
 from argparse import ArgumentParser
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field, is_dataclass
 from sys import argv, stderr, stdout
-from urllib.parse import urlparse
 
-import paho_socket
 from mqttrpc import Dispatcher
-from paho.mqtt import client as mqttclient
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 from wb_modbus import bindings
 from wb_modbus import logger as mb_logger
 from wb_modbus import minimalmodbus
@@ -156,15 +153,7 @@ class DeviceManager:
     STATE_PUBLISH_TOPIC = "/wb-device-manager/state"
 
     def __init__(self, broker_url: str):
-        url = urlparse(broker_url)
-        client_id = "%s-%d" % (self.MQTT_CLIENT_NAME, os.getpid())
-        if url.scheme == "mqtt-tcp":
-            self._mqtt_connection = mqttclient.Client(client_id)
-        elif url.scheme == "unix":
-            self._mqtt_connection = paho_socket.Client(client_id)
-        else:
-            raise Exception("Unkown mqtt url scheme")
-
+        self._mqtt_connection = MQTTClient(self.MQTT_CLIENT_NAME, broker_url)
         self._rpc_client = mqtt_rpc.SRPCClient(self.mqtt_connection)
         self._state_update_queue = asyncio.Queue()
         self._asyncio_loop = asyncio.get_event_loop()
@@ -491,11 +480,11 @@ def main(args=argv):
     )
     parser.add_argument(
         "-b",
-        "--broker_url",
+        "--broker",
         dest="broker_url",
         type=str,
-        help="MQTT url",
-        default="unix:///var/run/mosquitto/mosquitto.sock",
+        help="MQTT broker url",
+        default=DEFAULT_BROKER_URL,
     )
     args = parser.parse_args(argv[1:])
 

--- a/wb/device_manager/mqtt_rpc.py
+++ b/wb/device_manager/mqtt_rpc.py
@@ -198,7 +198,7 @@ class AsyncMQTTServer:
 
     def _close_mqtt_connection(self):
         self._delete_retained()
-        self.mqtt_connection.disconnect()
+        self.mqtt_connection.stop()
         logger.info("Mqtt: close %s", self.mqtt_url_str)
 
     def _setup_event_loop(self):
@@ -214,7 +214,7 @@ class AsyncMQTTServer:
         self.mqtt_connection.on_message = self._on_mqtt_message
 
         try:
-            self.mqtt_connection.connect()
+            self.mqtt_connection.start()
         finally:
             logger.info("Registered to atexit hook: close %s", self.mqtt_url_str)
             atexit.register(lambda: self._close_mqtt_connection())


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

Test instructions:
```sh
$ wb-device-manager -b unix:///var/run/mosquitto/mosquitto.s
[INFO] Registered to atexit hook: close unix:///var/run/mosquitto/mosquitto.sock
[INFO] Mqtt: reconnect to unix:///var/run/mosquitto/mosquitto.sock -> 0
$ wb-device-manager -b tcp://127.0.0.1:1883
[INFO] Registered to atexit hook: close tcp://127.0.0.1:1883
[INFO] Mqtt: reconnect to tcp://127.0.0.1:1883 -> 0
$ wb-device-manager -b ws://127.0.0.1:18883
[INFO] Registered to atexit hook: close ws://127.0.0.1:18883
[INFO] Mqtt: reconnect to ws://127.0.0.1:18883 -> 0
$ mqtt-rpc-client -d wb-device-manager -s bus-scan -m Start
'Ok'
```