### PR TITLE
Feature/60014 mge

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,4 @@
 | **com.wb.device_manager.device.read_fw_version_error** | Ошибка modbus-коммуникации с устройством (чтение fw_version) | ```null``` |
 | **com.wb.device_manager.device.read_fw_signature_error** | Ошибка modbus-коммуникации с устройством (чтение fw_signature) | ```null``` |
 | **com.wb.device_manager.device.read_device_signature_error** | Ошибка modbus-коммуникации с устройством (чтение device_signature) | ```null``` |
+| **com.wb.device_manager.device.read_serial_params_error** | Ошибка modbus-коммуникации с устройством (чтение serial-настроек; актуально для tcp портов) | ```null``` |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.6.0) stable; urgency=medium
+
+  * Add modbus rtu-over-tcp devices scanning (should be polled via wb-mqtt-serial already)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 31 Aug 2023 18:00:01 +0300
+
 wb-device-manager (1.5.6) stable; urgency=medium
 
   * Fix PKG-INFO

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -47,8 +47,10 @@ class TestRPCClient(unittest.IsolatedAsyncioTestCase):
             {"address": "192.168.0.7", "port": 23},
         ]
         assumed_response = {
-            "serial" : ["/dev/ttyRS485-1", "/dev/ttyRS485-2"],
-            "tcp" : ["192.168.0.7:23",],
+            "serial": ["/dev/ttyRS485-1", "/dev/ttyRS485-2"],
+            "tcp": [
+                "192.168.0.7:23",
+            ],
         }
         self.mock_response(response)
         ret = await self.device_manager.get_ports()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -80,8 +80,8 @@ class TestExternalDeviceErrors(unittest.IsolatedAsyncioTestCase):
             main.ReadFWSignatureDeviceError(),
             main.ReadFWVersionDeviceError(),
         ]
-        ret = await self.device_manager.fill_device_info(self.device_info, self.mb_conn)
-        self.assertListEqual(ret, assumed_errors)
+        await self.device_manager.fill_device_info(self.device_info, self.mb_conn)
+        self.assertListEqual(self.device_info.errors, assumed_errors)
 
 
 class TestDeviceManager(unittest.TestCase):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -46,10 +46,13 @@ class TestRPCClient(unittest.IsolatedAsyncioTestCase):
             },
             {"address": "192.168.0.7", "port": 23},
         ]
-        assumed_response = ["/dev/ttyRS485-1", "/dev/ttyRS485-2"]
+        assumed_response = {
+            "serial" : ["/dev/ttyRS485-1", "/dev/ttyRS485-2"],
+            "tcp" : ["192.168.0.7:23",],
+        }
         self.mock_response(response)
-        ret = await self.device_manager._get_ports()
-        self.assertListEqual(ret, assumed_response)
+        ret = await self.device_manager.get_ports()
+        self.assertDictEqual(ret, assumed_response)
 
 
 class TestExternalDeviceErrors(unittest.IsolatedAsyncioTestCase):

--- a/tests/serial_bus_test.py
+++ b/tests/serial_bus_test.py
@@ -121,6 +121,11 @@ class AsyncModbusTestBase(unittest.IsolatedAsyncioTestCase):
         ret = await self.mb_connection.read_string(first_addr=200, regs_length=6)
         self.assertEqual(ret, string)
 
+    async def _test_read_u16_regs(self, mock, vals):
+        self.mock_response(mock)
+        ret = await self.mb_connection.read_u16_regs(first_addr=200, regs_length=6)
+        self.assertListEqual(ret, vals)
+
     async def _test_corrupted_answer(self, mock_without_crc):
         incorrect_crc = "0000"
         self.mock_response(mock_without_crc + incorrect_crc)
@@ -144,6 +149,11 @@ class TestWBAsyncModbus(AsyncModbusTestBase):
     async def test_read_string(self):
         await self._test_read_string(mock="0b030c00570042004d0041004f0034bbaa", string="WBMAO4")
 
+    async def test_read_u16_regs(self):
+        await self._test_read_u16_regs(
+            mock="0b030c00570042004d0041004f0034bbaa", vals=[87, 66, 77, 65, 79, 52]
+        )
+
     async def test_corrupted_answer(self):
         await self._test_corrupted_answer(mock_without_crc="0b030c00570042004d0041004f0034")
 
@@ -161,6 +171,11 @@ class TestWBAsyncExtendedModbus(AsyncModbusTestBase):
 
     async def test_read_string(self):
         await self._test_read_string(mock="fd6009fe48b6f5030c00570042004d0041004f0034e141", string="WBMAO4")
+
+    async def test_read_u16_regs(self):
+        await self._test_read_u16_regs(
+            mock="fd6009fe48b6f5030c00570042004d0041004f0034e141", vals=[87, 66, 77, 65, 79, 52]
+        )
 
     async def test_corrupted_answer(self):
         await self._test_corrupted_answer(mock_without_crc="fd6009fe48b6f5030c00570042004d0041004f0034")

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -104,9 +104,7 @@ class WBExtendedModbusScanner(WBModbusScanner):
     def __init__(self, port, rpc_client, instrument=mqtt_rpc.AsyncModbusInstrument):
         super().__init__(port, rpc_client)
         self.extended_modbus_wrapper = WBExtendedModbusWrapper()
-        self.instrument = instrument(
-            self.port, self.extended_modbus_wrapper.ADDR, self.rpc_client
-        )
+        self.instrument = instrument(self.port, self.extended_modbus_wrapper.ADDR, self.rpc_client)
 
     def _parse_device_data(self, device_data_bytestr):
         sn, slaveid = device_data_bytestr[:4], device_data_bytestr[4:]
@@ -199,7 +197,9 @@ class WBExtendedModbusScanner(WBModbusScanner):
 
 
 class WBAsyncModbus:
-    def __init__(self, addr, port, baudrate, parity, stopbits, rpc_client, instrument=mqtt_rpc.AsyncModbusInstrument):
+    def __init__(
+        self, addr, port, baudrate, parity, stopbits, rpc_client, instrument=mqtt_rpc.AsyncModbusInstrument
+    ):
         self.device = instrument(port, addr, rpc_client)
         self.addr = addr
         self.port = port
@@ -284,7 +284,9 @@ class WBAsyncExtendedModbus(WBAsyncModbus):
     Look at https://github.com/wirenboard/libwbmcu-modbus/blob/master/wbm_ext.md for more info
     """
 
-    def __init__(self, sn, port, baudrate, parity, stopbits, rpc_client, instrument=mqtt_rpc.AsyncModbusInstrument):
+    def __init__(
+        self, sn, port, baudrate, parity, stopbits, rpc_client, instrument=mqtt_rpc.AsyncModbusInstrument
+    ):
         dummy_slaveid = 0  # for compatibility with minimalmodbus checks
         super().__init__(dummy_slaveid, port, baudrate, parity, stopbits, rpc_client, instrument)
         self.serial_number = sn

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -249,9 +249,8 @@ class WBAsyncModbus:
             ret = ret.replace(placeholder, "")  # 'A1B2C3' bytes-only string
         return str(unhexlify(ret).decode(encoding="utf-8", errors="backslashreplace")).strip()
 
-    async def read_string(self, first_addr, regs_length):
+    async def _do_read(self, payloadformat, first_addr, regs_length=1):
         funcode = 3
-        payloadformat = minimalmodbus._PAYLOADFORMAT_STRING
 
         request = self._build_request(funcode=funcode, reg=first_addr, number_of_regs=regs_length)
 
@@ -269,7 +268,14 @@ class WBAsyncModbus:
             response_bytestr=response,
             payloadformat=payloadformat,
         )
+        return ret
+
+    async def read_string(self, first_addr, regs_length):
+        ret = await self._do_read(minimalmodbus._PAYLOADFORMAT_STRING, first_addr, regs_length)
         return self._str_to_wb(ret)
+
+    async def read_u16_regs(self, first_addr, regs_length):
+        return await self._do_read(minimalmodbus._PAYLOADFORMAT_REGISTERS, first_addr, regs_length)
 
 
 class WBAsyncExtendedModbus(WBAsyncModbus):


### PR DESCRIPTION
Хотели узнать, работает ли быстрый модбас через mge. Работает!

Но в device-manager-е поддержкой сканирования через mge и не пахло.

Концептуально: для mge появился tcp-инструмент, который подсовывает порт и ip в rpc-запрос сериалу.
Вытащил инструмент наружу, где надо.
Для tcp-портов снаружи нет serial настроечек (а видеть их хочется) => вычитываем с устройств

собрал на коленке всякого интересного (2 mge)
![image](https://github.com/wirenboard/wb-device-manager/assets/25829054/c6ab93d8-4717-4a1f-a9c9-3bb3948175d2)
