### PR TITLE
Fix long reaction to stop scanning request

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.6.1) stable; urgency=medium
+
+  * Fix long reaction to stop scanning request
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 23 Oct 2023 14:39:54 +0500
+
 wb-device-manager (1.6.0) stable; urgency=medium
 
   * Add modbus rtu-over-tcp devices scanning (should be polled via wb-mqtt-serial already)

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -172,7 +172,6 @@ class DeviceManager:
         self._bus_scanning_task = None
         self._bus_scanning_task_cancel_event = asyncio.Event()
 
-
     @property
     def mqtt_connection(self):
         return self._mqtt_connection


### PR DESCRIPTION
Иногда при вызове `cancel` asyncio задача `scan_serial_bus` получает управление только после выполнения всех задач из `gather`. В результате она не может оперативно завершиться.