### PR TITLE
Fix device signatures reading

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.7.0) stable; urgency=medium
+
+  * Fix device signatures reading
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 21 Feb 2024 08:51:36 +0500
+
 wb-device-manager (1.6.1) stable; urgency=medium
 
   * Fix long reaction to stop scanning request

--- a/tests/serial_bus_test.py
+++ b/tests/serial_bus_test.py
@@ -52,7 +52,7 @@ class TestMBExtendedScanner(unittest.IsolatedAsyncioTestCase):
             ("fffffffffffffffffd6003fed2efd601501a0000000000000000", "FED2EFD601"),
             ("fffffffffffffffffd60033938169d38f7000000000000000000", "3938169D38"),  # crc ends with zeroes
         ]
-        for (mock, assumed_response) in mocks:
+        for mock, assumed_response in mocks:
             self.mock_response(mock)
             ret = await self.scanner.get_next_device_data(
                 cmd_code=self.scanner.extended_modbus_wrapper.CMDS.single_scan, uart_params=self.uart_params

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -248,7 +248,7 @@ class DeviceManager:
                     first_addr=bindings.WBModbusDeviceBase.COMMON_REGS_MAP["device_signature"],
                     regs_length=reg_len,
                 )
-                device_info.device_signature = device_signature.strip("\x02")  # WB-MAP* fws failure
+                device_info.device_signature = device_signature
                 device_info.title = device_signature.strip(
                     "\x02"
                 )  # TODO: store somewhere human-readable titles


### PR DESCRIPTION
Do not strip 0x02 at the end of MAP signatures

Из-за удаления байтиков сигнатуры разных устройств стали одинаковыми