### PR TITLE
Continue scanning after receiving invalid Modbus packet

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.8.1) stable; urgency=medium
+
+  * Do not stop the whole scanning on a port after receiving invalid Modbus packet
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 28 May 2024 18:17:22 +0500
+
 wb-device-manager (1.8.0) stable; urgency=medium
 
   * Add scan_type and preserve_old_results parameters to bus-scan/Start RPC request

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -485,6 +485,8 @@ class DeviceManager:
 
         except minimalmodbus.NoResponseError:
             logger.debug("No %s-modbus devices on %s", "extended" if is_ext_scan else "ordinary", debug_str)
+        except minimalmodbus.InvalidResponseError as err:
+            logger.error("Invalid response during scan %s: %s", debug_str, err)
         except Exception:
             logger.exception("Unhandled exception during scan %s", debug_str)
             self._ports_errored.add(debug_str)


### PR DESCRIPTION
Если при сканировании получали битый пакет, то сканирование на этом порту прекращалось совсем, непроверенные настройки порта не перебирались.