### PR TITLE
Stop slow scan faster

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.9.1) stable; urgency=medium
+
+  * Stop slow scan faster
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 11 Jul 2024 11:35:29 +0500
+
 wb-device-manager (1.9.0) stable; urgency=medium
 
   * Add port path parameter to bus-scan/Start RPC request

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -51,11 +51,13 @@ class WBModbusScanner:
         )
         return sn
 
-    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2):
+    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2, cancel_condition=None):
         uart_params = {"baudrate": baudrate, "parity": parity, "stopbits": stopbits}
         logger.debug("Scanning %s %s", self.port, str(uart_params))
 
         for slaveid in random.sample(range(1, 247), 246):
+            if cancel_condition is not None and cancel_condition.should_cancel():
+                return
             try:
                 sn = await self.get_serial_number(slaveid, uart_params)
                 sn = str(sn)
@@ -211,7 +213,7 @@ class WBExtendedModbusScanner(WBModbusScanner):
                 )
             )
 
-    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2):
+    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2, cancel_condition=None):
         uart_params = {"baudrate": baudrate, "parity": parity, "stopbits": stopbits}
 
         response_timeout = self._get_arbitration_timeout(baudrate)
@@ -222,6 +224,8 @@ class WBExtendedModbusScanner(WBModbusScanner):
             cmd_code=self.extended_modbus_wrapper.CMDS.scan_init, uart_params=uart_params
         )
         while sn_slaveid is not None:
+            if cancel_condition is not None and cancel_condition.should_cancel():
+                return
             slaveid, sn = self._parse_device_data(sn_slaveid)
             logger.info("Got device: %d %s %s", slaveid, sn, str(uart_params))
             self.uart_params_mapping.update(


### PR DESCRIPTION
Проверяю признак того, что надо завершить сканирование, перед каждым новым адресом. Это существенно быстрее. Раньше проверялось только перед каждыми новыми настройками порта и ждало перебора всех адресов