### PR TITLE
Fix reading of WB-MAP serial numbers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.9.2) stable; urgency=medium
+
+  * Fix reading of WB-MAP serial numbers
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 11 Sep 2024 15:31:34 +0500
+
 wb-device-manager (1.9.1) stable; urgency=medium
 
   * Stop slow scan faster

--- a/wb/device_manager/main.py
+++ b/wb/device_manager/main.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid
 from argparse import ArgumentParser
@@ -21,6 +22,9 @@ from . import logger, mqtt_rpc, serial_bus
 
 EXIT_INVALIDARGUMENT = 2
 EXIT_FAILURE = 1
+
+
+WBMAP_MARKER = re.compile("\S*MAP\d+\S*")  # *MAP%d* matches
 
 
 @dataclass
@@ -267,6 +271,8 @@ class DeviceManager:
                     "\x02"
                 )  # TODO: store somewhere human-readable titles
                 err_ctx = None
+                if WBMAP_MARKER.match(device_signature):
+                    device_info.sn = device_info.sn - 0xFE000000
                 break
             except minimalmodbus.ModbusException as e:
                 err_ctx = e


### PR DESCRIPTION
Для WB-MAP надо вычитать 0xFE000000

https://docs.google.com/document/d/1QvdRnWG-bDIEzfHByxsmdirdtRrDVPuYOnoTg_0Qa64/edit#heading=h.7gz31760unmg