### PR TITLE
Fix build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,13 @@
+wb-device-manager (1.10.1) stable; urgency=medium
+
+  * Fix build, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 13 Sep 2024 13:40:00 +0400
+
 wb-device-manager (1.10.0) stable; urgency=medium
 
- * Add fw-update/GetFirmwareInfo RPC for requesting information about device firmware
- * Add fw-update/Update RPC for updating firmwares of Wiren Board devices
+  * Add fw-update/GetFirmwareInfo RPC for requesting information about device firmware
+  * Add fw-update/Update RPC for updating firmwares of Wiren Board devices
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 12 Sep 2024 17:43:56 +0500
 

--- a/wb/device_manager/bus_scan.py
+++ b/wb/device_manager/bus_scan.py
@@ -12,7 +12,7 @@ from wb_modbus import bindings, minimalmodbus
 
 from . import logger, mqtt_rpc, serial_bus
 
-WBMAP_MARKER = re.compile("\S*MAP\d+\S*")  # *MAP%d* matches
+WBMAP_MARKER = re.compile(r"\S*MAP\d+\S*")  # *MAP%d* matches
 
 
 @dataclass

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -47,7 +47,7 @@ class DeviceUpdateInfo:
     progress: int = 0
     from_fw: str = None
     to_fw: str = None
-    error: StateError = StateError()
+    error: StateError = field(default_factory=StateError)
 
     def __eq__(self, o):
         return self.slave_id == o.slave_id and self.port == o.port


### PR DESCRIPTION
```sh
_____________________ ERROR collecting tests/main_test.py ______________________
tests/main_test.py:10: in <module>
    from wb.device_manager import main
wb/device_manager/main.py:15: in <module>
    from .firmware_update import FirmwareUpdater
wb/device_manager/firmware_update.py:43: in <module>
    @dataclass
../python3-3.12.5/lib/python3.12/dataclasses.py:1275: in dataclass
    return wrap(cls)
../python3-3.12.5/lib/python3.12/dataclasses.py:1265: in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
../python3-3.12.5/lib/python3.12/dataclasses.py:994: in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
../python3-3.12.5/lib/python3.12/dataclasses.py:852: in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
E   ValueError: mutable default <class 'wb.device_manager.firmware_update.StateError'> for field error is not allowed: use default_factory
```

```sh
wb/device_manager/bus_scan.py:15: SyntaxWarning: invalid escape sequence '\S'
    WBMAP_MARKER = re.compile("\S*MAP\d+\S*")  # *MAP%d* matches
```
```sh
W: wb-device-manager: syntax-error-in-debian-changelog line 3 "unrecognised line"
W: wb-device-manager: syntax-error-in-debian-changelog line 4 "unrecognised line"
```