### PR TITLE
Fix scan crashing on WB-MAP*

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.10.3) stable; urgency=medium
+
+  * Fix scan crashing on WB-MAP*
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 19 Sep 2024 09:36:31 +0500
+
 wb-device-manager (1.10.2) stable; urgency=medium
 
   * Run tests on pytest, no functional changes

--- a/tests/serial_bus_test.py
+++ b/tests/serial_bus_test.py
@@ -182,3 +182,10 @@ class TestWBAsyncExtendedModbus(AsyncModbusTestBase):
 
     async def test_slave_reported(self):
         await self._test_slave_reported(illegal_data_address_mock="fd6009fe48b6f58302ea17")
+
+
+class TestFixSn(unittest.TestCase):
+    def test_fix_sn(self):
+        sn = 0xFE123456
+        self.assertEqual(serial_bus.fix_sn("WB-MAP12E", sn), 0x00123456)
+        self.assertEqual(serial_bus.fix_sn("WB-MR6C", sn), sn)

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -13,11 +13,23 @@ from . import logger, mqtt_rpc
 WBMAP_MARKER = re.compile(r"\S*MAP\d+\S*")  # *MAP%d* matches
 
 
-def fix_sn(device_model: str, sn: int) -> int:
+def fix_sn(device_model: str, raw_sn: int) -> int:
+    """
+    Raw value in registers should be adjusted to get the actual serial number.
+    For example, WB-MAP* devices use only 25 bits for serial number and higher bits are set to 1.
+
+    Args:
+        device_model (str): The model of the device.
+        raw_sn (int): Raw serial number of the device read from registers.
+
+    Returns:
+        int: The adjusted serial number.
+
+    """
     # WB-MAP* uses 25 bit for serial number
     if WBMAP_MARKER.match(device_model):
-        return sn - 0xFE000000
-    return sn
+        return raw_sn - 0xFE000000
+    return raw_sn
 
 
 class WBModbusScanner:

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -10,6 +10,15 @@ from wb_modbus import bindings, minimalmodbus
 
 from . import logger, mqtt_rpc
 
+WBMAP_MARKER = re.compile(r"\S*MAP\d+\S*")  # *MAP%d* matches
+
+
+def fix_sn(device_model: str, sn: int) -> int:
+    # WB-MAP* uses 25 bit for serial number
+    if WBMAP_MARKER.match(device_model):
+        return sn - 0xFE000000
+    return sn
+
 
 class WBModbusScanner:
     def __init__(self, port, rpc_client):


### PR DESCRIPTION
Для WB-MAP надо специально вычислять серийник и нельзя просто брать значение из регистров. Первая попытка исправить это привела к новому багу, т.к. серийник в разных местах кода то срока, то число. Теперь серийник читается корректно везде