### PR TITLE
Fix scan status publishing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.12.1) stable; urgency=medium
+
+  * Fix scan status publishing after bus-scan/Stop call
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 03 Oct 2024 16:10:13 +0500
+
 wb-device-manager (1.12.0) stable; urgency=medium
 
   * Add searching for devices in bootloader mode

--- a/wb/device_manager/bus_scan.py
+++ b/wb/device_manager/bus_scan.py
@@ -21,7 +21,6 @@ from .bus_scan_state import (
     ReadFWVersionDeviceError,
     ReadSerialParamsDeviceError,
     RPCCallTimeoutStateError,
-    ScanCancelCondition,
     SerialParams,
     get_all_uart_params,
     make_uuid,
@@ -35,7 +34,6 @@ class BusScanner:
         self._rpc_client = rpc_client
         self._asyncio_loop = asyncio_loop
         self._bus_scanning_task = None
-        self._bus_scanning_task_cancel_condition = None
         self._state_manager = BusScanStateManager(mqtt_connection, asyncio_loop)
 
     @property
@@ -137,7 +135,6 @@ class BusScanner:
             preserve_old_results,
             port,
         )
-        self._bus_scanning_task_cancel_condition = ScanCancelCondition()
         self._bus_scanning_task = self.asyncio_loop.create_task(
             self.scan_serial_bus(scan_type, preserve_old_results, port, out_of_order_slave_ids),
             name="Scan serial bus (long running)",
@@ -151,7 +148,6 @@ class BusScanner:
         """
         if self._bus_scanning_task and not self._bus_scanning_task.done():
             logger.debug("Stop bus scanning")
-            self._bus_scanning_task_cancel_condition.request_cancel()
             self._bus_scanning_task.cancel()
             try:
                 await self._bus_scanning_task
@@ -207,7 +203,6 @@ class BusScanner:
                 bootloader_mode_scanner = BootloaderModeScanner(
                     SerialRPCWrapper(self.rpc_client),
                     self._state_manager,
-                    self._bus_scanning_task_cancel_condition,
                     get_all_uart_params,
                 )
                 await asyncio.gather(
@@ -222,7 +217,10 @@ class BusScanner:
                     *self._create_scan_tasks(ports, is_extended=False), return_exceptions=True
                 )
 
+            await self._state_manager.scan_complete()
+        except asyncio.CancelledError:
             await self._state_manager.scan_finished()
+            raise
         except Exception as e:
             logger.exception("Unhandled exception during overall scan %s", e)
             await self._state_manager.scan_finished(GenericStateError())
@@ -240,11 +238,7 @@ class BusScanner:
         await self._state_manager.add_scanning_port(debug_str, is_ext_scan)
 
         try:
-            async for slave_id, sn in scanner.scan_bus(
-                **scan_kwargs, cancel_condition=self._bus_scanning_task_cancel_condition
-            ):
-                if self._bus_scanning_task_cancel_condition.should_cancel():
-                    return
+            async for slave_id, sn in scanner.scan_bus(**scan_kwargs):
                 if self._state_manager.is_device_found(sn):
                     logger.debug("Device %s already scanned; skipping", str(sn))
                     continue
@@ -302,8 +296,6 @@ class BusScanner:
         )
 
         for bd, parity, stopbits, progress_percent in get_all_uart_params(stopbits=allowed_stopbits):
-            if self._bus_scanning_task_cancel_condition.should_cancel():
-                return
             await self.do_scan_port(
                 port,
                 scanner,

--- a/wb/device_manager/serial_bus.py
+++ b/wb/device_manager/serial_bus.py
@@ -72,13 +72,11 @@ class WBModbusScanner:
         )
         return sn
 
-    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2, cancel_condition=None):
+    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2):
         uart_params = {"baudrate": baudrate, "parity": parity, "stopbits": stopbits}
         logger.debug("Scanning %s %s", self.port, str(uart_params))
 
         for slaveid in random.sample(range(1, 247), 246):
-            if cancel_condition is not None and cancel_condition.should_cancel():
-                return
             try:
                 sn = await self.get_serial_number(slaveid, uart_params)
                 sn = str(sn)
@@ -234,7 +232,7 @@ class WBExtendedModbusScanner(WBModbusScanner):
                 )
             )
 
-    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2, cancel_condition=None):
+    async def scan_bus(self, baudrate=9600, parity="N", stopbits=2):
         uart_params = {"baudrate": baudrate, "parity": parity, "stopbits": stopbits}
 
         response_timeout = self._get_arbitration_timeout(baudrate)
@@ -245,8 +243,6 @@ class WBExtendedModbusScanner(WBModbusScanner):
             cmd_code=self.extended_modbus_wrapper.CMDS.scan_init, uart_params=uart_params
         )
         while sn_slaveid is not None:
-            if cancel_condition is not None and cancel_condition.should_cancel():
-                return
             slaveid, sn = self._parse_device_data(sn_slaveid)
             logger.info("Got device: %d %s %s", slaveid, sn, str(uart_params))
             self.uart_params_mapping.update(


### PR DESCRIPTION
Убрал спец событие для остановки сканирования. При вызове `cancel` и так вниз по иерархии спускается исключение `CancelledError`, и всё дерево сканирования останавливается.
Добавил спец обработку `CancelledError`, в которой обновляю статус сканирования