### PR TITLE
Improve exception logging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.14.1) stable; urgency=medium
+
+  * Improve exception logging during update
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 22 Oct 2024 10:27:37 +0500
+
 wb-device-manager (1.14.0) stable; urgency=medium
 
   * Allow update bootloader with fw-update/Update RPC


### PR DESCRIPTION
* Fix firmware update
* Improve exception logging

Для задач не делается await, так что исключения в них не обрабатываются и никуда не выводятся. Сделал вывод в лог. Ещё баг поправил с параметром при вызове `update_software`