### PR TITLE
Add device model to fw-update/GetFirmwareInfo RPC response

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ MQTT RPC запрос `wb-device-manager/fw-update/GetFirmwareInfo/client_id` п
     "available_bootloader": "2.2.2",
 
     // Признак того, что прошивка и загрузчик могут быть обновлены средствами wb-device-manager через RPC fw-update/Update
-    "can_update": false
+    "can_update": false,
+
+    // Модель устройства, получена, исходя из содержимого регистров 200-219
+    "model": "WB-LED"
 }
 ```
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.15.0) stable; urgency=medium
+
+  * Add device model to fw-update/GetFirmwareInfo RPC response
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 14 Nov 2024 10:00:14 +0500
+
 wb-device-manager (1.14.1) stable; urgency=medium
 
   * Improve exception logging during update

--- a/tests/firmware_update_test.py
+++ b/tests/firmware_update_test.py
@@ -101,17 +101,21 @@ class TestGetFirmwareInfo(unittest.IsolatedAsyncioTestCase):
     async def test_successful_read(self):
         reader_mock = AsyncMock()
         reader_mock.read = AsyncMock()
+        serial_rpc = AsyncMock()
+        serial_rpc.read = AsyncMock()
+        serial_rpc.read.return_value = "MAP12\x02E"
         firmware_info = FirmwareInfo(
             current_version="1", available=ReleasedBinary("2", "endpoint"), signature="sig"
         )
         firmware_info.bootloader.can_preserve_port_settings = True
         reader_mock.read.return_value = firmware_info
-        updater = FirmwareUpdater(AsyncMock(), None, None, reader_mock, None)
+        updater = FirmwareUpdater(AsyncMock(), serial_rpc, None, reader_mock, None)
         res = await updater.get_firmware_info(slave_id=1, port={"path": "test"})
 
         self.assertEqual(res.get("fw"), "1")
         self.assertEqual(res.get("available_fw"), "2")
         self.assertEqual(res.get("can_update"), True)
+        self.assertEqual(res.get("model"), "MAP12E")
 
 
 class TestFlashFw(unittest.IsolatedAsyncioTestCase):

--- a/wb/device_manager/bus_scan.py
+++ b/wb/device_manager/bus_scan.py
@@ -25,6 +25,7 @@ from .bus_scan_state import (
     get_all_uart_params,
     make_uuid,
 )
+from .firmware_update import get_human_readable_device_model
 from .serial_bus import fix_sn
 from .serial_rpc import SerialRPCWrapper
 
@@ -61,7 +62,7 @@ class BusScanner:
                     regs_length=reg_len,
                 )
                 device_info.device_signature = device_signature
-                device_info.title = device_signature.strip("\x02")
+                device_info.title = get_human_readable_device_model(device_signature)
                 err_ctx = None
                 device_info.sn = str(fix_sn(device_info.device_signature, int(device_info.sn)))
                 break


### PR DESCRIPTION
Добавил поле с моделью устройства.
Это нужно для формирования ссылки в веб-интерфейсе https://github.com/wirenboard/homeui/pull/644