### PR TITLE
Fix error handling during firmware update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-device-manager (1.16.2) stable; urgency=medium
+
+  * Fix error handling during firmware update.
+    Correctly publish the error in the status topic.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 11 Feb 2025 09:24:29 +0500
+
 wb-device-manager (1.16.1) stable; urgency=medium
 
   * Add scanner and fw update state republish on mosquitto restart

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -290,7 +290,7 @@ class UpdateStateNotifier:
             self._device_update_info.error = FileDownloadError()
         else:
             self._device_update_info.error = GenericStateError()
-            self._device_update_info.error.metadata = {exception: str(exception)}
+            self._device_update_info.error.metadata = {"exception": str(exception)}
         self._update_state.update(self._device_update_info)
 
     def delete(self, should_notify: bool = True) -> None:


### PR DESCRIPTION
Correctly publish the error in the status topic

Вместо строки, использовал сам объект исключения как ключ. Из-за этого падало преобразование в JSON, и ошибка не публиковалась в топик, homeui вечно показывал, что обновление в процессе