### PR TITLE
Retry firmware data block flashing on errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.16.3) stable; urgency=medium
+
+  * Retry firmware flashing on errors
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 11 Feb 2025 18:05:24 +0500
+
 wb-device-manager (1.16.2) stable; urgency=medium
 
   * Fix error handling during firmware update.

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -32,6 +32,7 @@ from .serial_rpc import (
     DEFAULT_BAUD_RATE,
     DEFAULT_PARITY,
     WB_DEVICE_PARAMETERS,
+    ModbusExceptionCode,
     ParameterConfig,
     SerialConfig,
     SerialExceptionBase,
@@ -39,6 +40,7 @@ from .serial_rpc import (
     SerialRPCWrapper,
     SerialTimeoutException,
     TcpConfig,
+    WBModbusException,
 )
 from .state_error import (
     DeviceResponseTimeoutError,
@@ -297,6 +299,40 @@ class UpdateStateNotifier:
         self._update_state.remove(self._device_update_info, should_notify)
 
 
+async def write_fw_data_block(serial_device: SerialDevice, chunk: bytes) -> None:
+    """
+    Writes a firmware data block to the serial device.
+    The device must be in bootloader mode.
+    Retries writing the chunk up to 3 times if there is a failure.
+    Slave device failure (0x04) Modbus exception is a successful write.
+    It means that the chunk is already written.
+
+    Args:
+        serial_device (SerialDevice): The serial device to write the firmware chunk to.
+        chunk (bytes): The firmware chunk to write.
+
+    Raises:
+        SerialExceptionBase derived exception: If there is a failure during flashing.
+    """
+    error_count = 0
+    MAX_ERRORS = 3
+    while True:
+        try:
+            try:
+                await serial_device.write(WB_DEVICE_PARAMETERS["fw_data_block"], chunk)
+                return
+            except WBModbusException as e:
+                # The device sends slave device failure (0x04) if the chunk is already written
+                if e.code == ModbusExceptionCode.SLAVE_DEVICE_FAILURE:
+                    return
+                raise e
+        except SerialExceptionBase as e:
+            # Could be an error during transmission, retry
+            error_count += 1
+            if error_count >= MAX_ERRORS:
+                raise e
+
+
 async def flash_fw(
     serial_device: SerialDevice, parsed_wbfw: ParsedWBFW, progress_notifier: UpdateStateNotifier
 ) -> None:
@@ -322,19 +358,9 @@ async def flash_fw(
         for i in range(0, len(parsed_wbfw.data), data_chunk_length)
     ]
 
-    # Due to bootloader's behavior, actual flashing failure is current-chunk failure + next-chunk failure
-    has_previous_chunk_failed = False
-
     for index, chunk in enumerate(chunks):
-        try:
-            await serial_device.write(WB_DEVICE_PARAMETERS["fw_data_block"], chunk)
-            progress_notifier.set_progress(int((index + 1) * 100 / len(chunks)))
-            has_previous_chunk_failed = False
-        except SerialExceptionBase as e:
-            if has_previous_chunk_failed:
-                raise e
-            has_previous_chunk_failed = True
-            continue
+        await write_fw_data_block(serial_device, chunk)
+        progress_notifier.set_progress(int((index + 1) * 100 / len(chunks)))
 
 
 async def reboot_to_bootloader(


### PR DESCRIPTION
Выяснил, что неверно была сделана обработка ошибок записи части прошивки при обновлении. Добавил повторные попытки записи при ошибках