### PR TITLE
Improve logging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.17.1) stable; urgency=medium
+
+  * Improve logging of firmware update errors
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 03 Apr 2025 15:28:10 +0500
+
 wb-device-manager (1.17.0) stable; urgency=medium
 
   * Fix a bug due to which some devices might not be found during scanning

--- a/debian/control
+++ b/debian/control
@@ -15,4 +15,4 @@ Provides: python3-wb-device-manager
 Depends: ${python3:Depends}, ${misc:Depends}, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.5), wb-mqtt-serial (>= 2.156.0~~), python3-wb-mcu-fw-updater (>= 1.6.1), python3-httplib2
 Recommends: wb-mqtt-homeui (>= 2.50.0)
 Description: Wiren Board modbus devices manager
-    This package contains a daemon that manages firmware update and new devices searching.
+ The daemon that manages firmware update and new devices searching.

--- a/debian/control
+++ b/debian/control
@@ -1,11 +1,10 @@
 Source: wb-device-manager
-Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: python
 Priority: optional
-XS-Python-Version: >= 3.9.1
 Build-Depends: dh-python, debhelper (>= 10), python3-all, python3-setuptools, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-wb-mcu-fw-updater, python3-mqttrpc (>= 1.1.5), python3-pytest, python3-httplib2
-Standards-Version: 3.9.1
-X-Python-Version: >= 3.9.1
+Standards-Version: 4.5.1
+X-Python3-Version: >= 3.9
 Homepage: https://github.com/wirenboard/wb-device-manager
 
 Package: wb-device-manager
@@ -15,4 +14,5 @@ Replaces: python3-wb-device-manager
 Provides: python3-wb-device-manager
 Depends: ${python3:Depends}, ${misc:Depends}, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.5), wb-mqtt-serial (>= 2.156.0~~), python3-wb-mcu-fw-updater (>= 1.6.1), python3-httplib2
 Recommends: wb-mqtt-homeui (>= 2.50.0)
-Description: Wiren Board modbus devices manager (python3 service; backend)
+Description: Wiren Board modbus devices manager
+    This package contains a daemon that manages firmware update and new devices searching.

--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,6 @@ export PYBUILD_NAME=wb_device_manager
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_installinit:
+	dh_installinit --noscripts

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -607,7 +607,7 @@ class FirmwareUpdater:
         try:
             res["fw"] = await self._fw_info_reader.read_fw_version(port_config, slave_id)
         except SerialExceptionBase as err:
-            logger.debug("Can't get firmware info for %s (%s): %s", slave_id, port_config, err)
+            logger.warning("Can't get firmware info for %s (%s): %s", slave_id, port_config, err)
             raise JSONRPCDispatchException(
                 code=MQTTRPCErrorCode.REQUEST_HANDLING_ERROR.value, message=str(err)
             ) from err
@@ -619,13 +619,13 @@ class FirmwareUpdater:
         try:
             signature = await self._fw_info_reader.read_fw_signature(port_config, slave_id)
         except SerialExceptionBase as err:
-            logger.debug("Can't get firmware signature for %s (%s): %s", slave_id, port_config, err)
+            logger.warning("Can't get firmware signature for %s (%s): %s", slave_id, port_config, err)
             return res
 
         try:
             res["available_fw"] = self._fw_info_reader.read_released_fw(signature).version
         except NoReleasedFwError as err:
-            logger.debug("Can't get released firmware info for %s (%s): %s", slave_id, port_config, err)
+            logger.warning("Can't get released firmware info for %s (%s): %s", slave_id, port_config, err)
 
         bootloader = await self._fw_info_reader.read_bootloader(port_config, slave_id, signature)
         res["bootloader"] = bootloader.current_version
@@ -636,7 +636,7 @@ class FirmwareUpdater:
                 slave_id, bootloader.can_preserve_port_settings, port_config
             )
         except SerialExceptionBase as err:
-            logger.debug("Can't check if firmware for %s (%s)is updatable: %s", slave_id, port_config, err)
+            logger.warning("Can't check if firmware for %s (%s)is updatable: %s", slave_id, port_config, err)
 
         return res
 

--- a/wb/device_manager/fw_downloader.py
+++ b/wb/device_manager/fw_downloader.py
@@ -105,9 +105,7 @@ def get_released_fw(
     logger.debug("Looking to %s (suite: %s)", url, release_suite)
     try:
         contents = binary_downloader.read_text_file(url)
-        fw_endpoint = str(
-            yaml.safe_load(contents).get("releases", {}).get(fw_signature, {}).get(release_suite)
-        )
+        fw_endpoint = yaml.safe_load(contents).get("releases", {}).get(fw_signature, {}).get(release_suite)
         if fw_endpoint:
             fw_endpoint = f"{FW_RELEASES_BASE_URL}/{fw_endpoint}"
             fw_version = parse_fw_version(fw_endpoint)

--- a/wb/device_manager/mqtt_rpc.py
+++ b/wb/device_manager/mqtt_rpc.py
@@ -62,24 +62,25 @@ class SRPCClient(rpcclient.TMQTTRPCClient):
 
     def __init__(self, client):
         super().__init__(client)
-        self.counter = 0
+        self._counter = 0
 
     async def make_rpc_call(self, driver, service, method, params, timeout):
-        self.counter += 1
-        logger.debug("RPC Client %d -> %s (rpc timeout: %.2fs)", self.counter, params, timeout)
+        self._counter += 1
+        call_id = self._counter
+        logger.debug("RPC Client %d -> %s (rpc timeout: %.2fs)", call_id, params, timeout)
         response_f = self.call_async(driver, service, method, params, result_future=RPCResultFuture)
         try:
             response = await asyncio.wait_for(response_f, timeout)
-            logger.debug("RPC Client %d <- %s", self.counter, response)
+            logger.debug("RPC Client %d <- %s", call_id, response)
             return response
         except asyncio.exceptions.TimeoutError as e:
-            logger.debug("RPC Client %d <- no answer", self.counter)
+            logger.debug("RPC Client %d <- no answer", call_id)
             raise MQTTRPCCallTimeoutError(
                 message="rpc call to %s/%s/%s -> %.2fs: no answer" % (driver, service, method, timeout),
                 data="rpc call params: %s" % str(params),
             ) from e
         except rpcclient.MQTTRPCError as e:
-            logger.debug("RPC Client %d <- error %s", self.counter, e)
+            logger.debug("RPC Client %d <- error %s", call_id, e)
             if e.code == MQTTRPCErrorCode.REQUEST_TIMEOUT_ERROR.value:
                 raise MQTTRPCRequestTimeoutError(e.rpc_message, e.data) from e
             raise e

--- a/wb/device_manager/mqtt_rpc.py
+++ b/wb/device_manager/mqtt_rpc.py
@@ -60,19 +60,26 @@ class SRPCClient(rpcclient.TMQTTRPCClient):
     Stores internal future-like objs (with rpc-call result), filled from outer on_mqtt_message callback
     """
 
+    def __init__(self, client):
+        super().__init__(client)
+        self.counter = 0
+
     async def make_rpc_call(self, driver, service, method, params, timeout):
-        logger.debug("RPC Client -> %s (rpc timeout: %.2fs)", params, timeout)
+        self.counter += 1
+        logger.debug("RPC Client %d -> %s (rpc timeout: %.2fs)", self.counter, params, timeout)
         response_f = self.call_async(driver, service, method, params, result_future=RPCResultFuture)
         try:
             response = await asyncio.wait_for(response_f, timeout)
-            logger.debug("RPC Client <- %s", response)
+            logger.debug("RPC Client %d <- %s", self.counter, response)
             return response
         except asyncio.exceptions.TimeoutError as e:
+            logger.debug("RPC Client %d <- no answer", self.counter)
             raise MQTTRPCCallTimeoutError(
                 message="rpc call to %s/%s/%s -> %.2fs: no answer" % (driver, service, method, timeout),
                 data="rpc call params: %s" % str(params),
             ) from e
         except rpcclient.MQTTRPCError as e:
+            logger.debug("RPC Client %d <- error %s", self.counter, e)
             if e.code == MQTTRPCErrorCode.REQUEST_TIMEOUT_ERROR.value:
                 raise MQTTRPCRequestTimeoutError(e.rpc_message, e.data) from e
             raise e


### PR DESCRIPTION
* Move fw-update/GetFirmwareInfo internal errors from debug to warnings
* Add rpc call id to logs
* Improve handling of errors during released firmware search
* Fix debian lintian errors

___________________________________
**Что происходит; кому и зачем нужно:**
Логи не позволяют понять, что пошло не так.
- RPC запросы асинхронные, сложно сопоставить запрос и ответ
- В процессе запроса информации об устройстве, ошибки были видны только в дебаге
- При поиске прошивки на сервере, None могло преобразоваться с строку. Оно, конечно, падало на следующем шаге, но в логе была странная ошибка

___________________________________
**Что поменялось для пользователей:**

Логи стали содержать больше информации

___________________________________
**Как проверял/а:**

Включил дебаг и посмотрел в лог

