### PR TITLE
Fix device signature reading

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.18.0) stable; urgency=medium
+
+  * Fix searching of WB-MAP energy meters
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 09 Apr 2025 18:17:40 +0500
+
 wb-device-manager (1.17.1) stable; urgency=medium
 
   * Improve logging of firmware update errors

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Breaks: python3-wb-device-manager
 Replaces: python3-wb-device-manager
 Provides: python3-wb-device-manager
-Depends: ${python3:Depends}, ${misc:Depends}, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.5), wb-mqtt-serial (>= 2.156.0~~), python3-wb-mcu-fw-updater (>= 1.6.1), python3-httplib2
+Depends: ${python3:Depends}, ${misc:Depends}, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.5), wb-mqtt-serial (>= 2.158.7~~), python3-wb-mcu-fw-updater (>= 1.6.1), python3-httplib2
 Recommends: wb-mqtt-homeui (>= 2.50.0)
 Description: Wiren Board modbus devices manager
  The daemon that manages firmware update and new devices searching.

--- a/wb/device_manager/one_by_one_scan.py
+++ b/wb/device_manager/one_by_one_scan.py
@@ -50,8 +50,8 @@ class OneByOneBusScanner:
                     first_addr=bindings.WBModbusDeviceBase.COMMON_REGS_MAP["device_signature"],
                     regs_length=reg_len,
                 )
-                device_info.device_signature = device_signature
-                device_info.title = get_human_readable_device_model(device_signature)
+                device_info.device_signature = get_human_readable_device_model(device_signature)
+                device_info.title = device_info.device_signature
                 err_ctx = None
                 device_info.sn = str(fix_sn(device_info.device_signature, int(device_info.sn)))
                 break


### PR DESCRIPTION
Exclude 0x02 bytes from device signatures as they are removed from signatures in templates

___________________________________
**Что происходит; кому и зачем нужно:**
При медленном сканировании больше не шлём в поле device_signature символы 0x02.
Они появляются, если читать модель устройства из счётчиков с прошивкой 2.x.x.
Это поле используется для поиска подходящего шаблона после сканирования.
В шаблонах было прописано значение с 0x02.
После переноса сканирования с питона в wb-mqtt-serial, модель устройства стала читаться как обычная строка, т.е. без 0x02.
Выбор шаблона развалился.
Решили не дорабатывать wb-mqtt-serial, т.к. это достаточно много кода.
Прописали в шаблонах версию прошивки и убрали 0x02.
Теперь сломался выбор после медленного сканирования, т.к. оно всё ещё через питон, и выдаёт модель с 0x02.

___________________________________
**Что поменялось для пользователей:**
Ничего

___________________________________
**Как проверял/а:**
Поставили свежий wb-mqtt-serial и нашли счётчик медленным сканированием, убедились, что выбран нужный шаблон

