### PR TITLE
Add caching

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-device-manager (1.18.1) stable; urgency=medium
 
   * Improve getting information about released firmware versions speed
+  * Add caching of information about released firmwares, bootloaders and firmware binaries.
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 21 Apr 2025 10:50:50 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.18.1) stable; urgency=medium
+
+  * Improve getting information about released firmware versions speed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 21 Apr 2025 10:50:50 +0500
+
 wb-device-manager (1.18.0) stable; urgency=medium
 
   * Fix searching of WB-MAP energy meters

--- a/wb/device_manager/ttl_lru_cache.py
+++ b/wb/device_manager/ttl_lru_cache.py
@@ -9,15 +9,34 @@ from functools import lru_cache
 # Taken from https://stackoverflow.com/questions/31771286/python-in-memory-cache-with-time-to-live
 def ttl_lru_cache(seconds_to_live: int, maxsize: int = 10):
     """
-    Time aware lru caching
+    A decorator that provides a time-aware Least Recently Used (LRU) caching mechanism.
+
+    This decorator caches the results of a function call for a specified duration.
+    The cache is invalidated and refreshed every `seconds_to_live` seconds.
+    It also limits the number of cached items to `maxsize`.
+
+    Args:
+        seconds_to_live (int): The duration (in seconds) for which a cached result is valid.
+        maxsize (int, optional): The maximum number of items to store in the cache. Defaults to 10.
+
+    Returns:
+        Callable: A decorated function with TTL-based LRU caching applied.
+
+    Usage:
+        @ttl_lru_cache(seconds_to_live=60, maxsize=100)
+        def my_function(arg1, arg2):
+            # Function implementation
+            pass
     """
 
     def wrapper(func):
 
+        # lru_cache uses a hash of all the arguments to determine a cache hit.
+        # A dummy argument __ttl is used to group calls with the same arguments but at different times.
+        # __ttl is the current time divided by the seconds_to_live and changes every seconds_to_live seconds.
+        # So cache invalidates every seconds_to_live seconds.
         @lru_cache(maxsize)
         def inner(__ttl, *args, **kwargs):
-            # Note that __ttl is not passed down to func,
-            # as it's only used to trigger cache miss after some time
             return func(*args, **kwargs)
 
         return lambda *args, **kwargs: inner(time.time() // seconds_to_live, *args, **kwargs)

--- a/wb/device_manager/ttl_lru_cache.py
+++ b/wb/device_manager/ttl_lru_cache.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import time
+from functools import lru_cache
+
+
+# Taken from https://stackoverflow.com/questions/31771286/python-in-memory-cache-with-time-to-live
+def ttl_lru_cache(seconds_to_live: int, maxsize: int = 10):
+    """
+    Time aware lru caching
+    """
+
+    def wrapper(func):
+
+        @lru_cache(maxsize)
+        def inner(__ttl, *args, **kwargs):
+            # Note that __ttl is not passed down to func,
+            # as it's only used to trigger cache miss after some time
+            return func(*args, **kwargs)
+
+        return lambda *args, **kwargs: inner(time.time() // seconds_to_live, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Cache released firmware and bootloader information, firmware binaries

___________________________________
**Что происходит; кому и зачем нужно:**
Использовал для запросов версий прошивок и самих прошивок libhttp2, т.к. в ней есть кэш. Оказалось, что из-за настроек нашего сервера ничего не кэшируется. Сделал кэш

___________________________________
**Что поменялось для пользователей:**
Запрос спежих прошивок при большом числе йстройств в инстралляции ускорился. Раньше вообще ничего не показывалось из-за таймаута RPC

___________________________________
**Как проверял/а:**
Подключил нескролько устройств, посмотрел в логе, соклько времени занимает запрос версии прошивки, сравнил с исправленной версией

