### PR TITLE
Fix timeout error message formatting

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.19.3) stable; urgency=medium
+
+  * Fix timeout error message
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 04 Aug 2025 19:14:52 +0500
+
 wb-device-manager (1.19.2) stable; urgency=medium
 
   * Improve error handling during firmware update

--- a/wb/device_manager/mqtt_rpc.py
+++ b/wb/device_manager/mqtt_rpc.py
@@ -76,7 +76,7 @@ class SRPCClient(rpcclient.TMQTTRPCClient):  # pylint:disable=too-few-public-met
         except asyncio.exceptions.TimeoutError as e:
             logger.debug("RPC Client %d <- no answer", call_id)
             raise MQTTRPCCallTimeoutError(
-                message=f"rpc call to {driver}/{service}/{method} -> {timeout:.2fs}: no answer",
+                message=f"rpc call to {driver}/{service}/{method} -> {timeout:.2f}s: no answer",
                 data=f"rpc call params: {str(params)}",
             ) from e
         except rpcclient.MQTTRPCError as e:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Кривое форматирование в сообщении об ошибке. В результате писало не про таймаут, а про Invalid format specifier 

___________________________________
**Что поменялось для пользователей:**
Логи стали понятнее

___________________________________
**Как проверял/а:**


