### PR TITLE
Add device/SetPoll RPC calls before and after device firmware update routines

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.20.0) stable; urgency=medium
+
+  * Add device/SetPoll RPC calls before and after device firmware update routines
+
+ -- Ilya Titiov <ilya.titov@wirenboard.com>  Thu, 14 Aug 2025 11:09:52 +0300
+
 wb-device-manager (1.19.3) stable; urgency=medium
 
   * Fix timeout error message

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -258,6 +258,9 @@ class SerialDevice:
     def __post_init__(self) -> None:
         self._description = f"slave id: {self._slave_id}, {self._port_config}"
 
+    async def set_poll(self, poll) -> None:
+        await self._serial_rpc.set_poll(self._port_config, self._slave_id, poll)
+
     async def write(
         self, param_config: ParameterConfig, value: Union[int, bytes], response_timeout_s: float = None
     ) -> None:
@@ -425,12 +428,14 @@ async def update_software(
     device_model = get_human_readable_device_model(await read_device_model(serial_device))
     sn = await read_sn(serial_device, device_model)
     try:
+        await serial_device.set_poll(False) # suspend device poll
         await reboot_to_bootloader(serial_device, bootloader_can_preserve_port_settings)
         await flash_fw(
             serial_device,
             download_wbfw(binary_downloader, software.available.endpoint),
             update_state_notifier,
         )
+        await serial_device.set_poll(True) # resume device poll
     except (WBRemoteStorageError, SerialExceptionBase) as e:
         update_state_notifier.set_error_from_exception(e)
         logger.error(
@@ -474,11 +479,13 @@ async def restore_firmware(
 
     update_state_notifier.set_progress(0)
     try:
+        await serial_device.set_poll(False) # suspend device poll
         await flash_fw(
             serial_device,
             download_wbfw(binary_downloader, firmware.endpoint),
             update_state_notifier,
         )
+        await serial_device.set_poll(True) # resume device poll
     except (WBRemoteStorageError, SerialExceptionBase) as e:
         update_state_notifier.set_error_from_exception(e)
         logger.error("Firmware restore of %s failed: %s", serial_device.description, e)

--- a/wb/device_manager/serial_rpc.py
+++ b/wb/device_manager/serial_rpc.py
@@ -226,6 +226,27 @@ class SerialRPCWrapper:
         wb_devices_response_time_s = 8e-3  # devices with old fws
         return wb_devices_response_time_s
 
+    async def _make_request(self, service: str, method: str, parms: dict) -> bytes:
+        try:
+            response = await self.rpc_client.make_rpc_call(
+                driver="wb-mqtt-serial",
+                service=service,
+                method=method,
+                params=parms,
+                timeout=DEFAULT_RPC_CALL_TIMEOUT_MS / 1000,
+            )
+        except rpcclient.MQTTRPCError as err:
+            if err.code == MQTTRPCErrorCode.REQUEST_TIMEOUT_ERROR.value:
+                raise SerialTimeoutException(str(err)) from err
+            if err.code == MQTTRPCErrorCode.RPC_CALL_TIMEOUT.value:
+                raise SerialRPCTimeoutException(str(err)) from err
+            raise SerialCommunicationException(str(err)) from err
+
+        if "exception" in response:
+            raise WBModbusException(response["exception"]["msg"], response["exception"]["code"])
+
+        return bytes.fromhex(str(response.get("response", "")))
+
     async def _communicate(  # pylint: disable=too-many-arguments
         self,
         port_config: Union[SerialConfig, TcpConfig],
@@ -255,25 +276,20 @@ class SerialRPCWrapper:
             rpc_request["format"] = "HEX"
             rpc_request["msg"] = data.hex()
 
-        try:
-            response = await self.rpc_client.make_rpc_call(
-                driver="wb-mqtt-serial",
-                service="port",
-                method="Load",
-                params=rpc_request,
-                timeout=DEFAULT_RPC_CALL_TIMEOUT_MS / 1000,
-            )
-        except rpcclient.MQTTRPCError as err:
-            if err.code == MQTTRPCErrorCode.REQUEST_TIMEOUT_ERROR.value:
-                raise SerialTimeoutException(str(err)) from err
-            if err.code == MQTTRPCErrorCode.RPC_CALL_TIMEOUT.value:
-                raise SerialRPCTimeoutException(str(err)) from err
-            raise SerialCommunicationException(str(err)) from err
+        return self._make_request("port", "Load", rpc_request)
 
-        if "exception" in response:
-            raise WBModbusException(response["exception"]["msg"], response["exception"]["code"])
+    async def _set_poll(self, port_config: Union[SerialConfig, TcpConfig], slave_id: int, poll: bool) -> None:
+        rpc_request = {
+            "slave_id": slave_id,
+            "poll": poll
+        }
+        if isinstance(port_config, SerialConfig):
+            rpc_request["path"] = port_config.path
+        else:
+            rpc_request["ip"] = port_config.address
+            rpc_request["port"] = port_config.port
 
-        return bytes.fromhex(str(response.get("response", "")))
+        self._make_request("device", "SetPoll", rpc_request)
 
     async def read(
         self,


### PR DESCRIPTION
Добавил вызовы RPC `device/SetPoll` для отключения опроса перед прошивкой и включения обратно после прошивки устройств.