### PR TITLE
Add device/SetPoll RPC call on device firmware update failure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.20.1) stable; urgency=medium
+
+  * Add device/SetPoll RPC call on device firmware update failure
+
+ -- Ilya Titiov <ilya.titov@wirenboard.com>  Thu, 14 Aug 2025 11:09:52 +0300
+
 wb-device-manager (1.20.0) stable; urgency=medium
 
   * Add device/SetPoll RPC calls before and after device firmware update routines

--- a/tests/firmware_update_test.py
+++ b/tests/firmware_update_test.py
@@ -303,6 +303,7 @@ class TestRestoreFirmware(unittest.IsolatedAsyncioTestCase):
         mock.set_progress = Mock()
         mock.set_poll = AsyncMock()
         mock.set_error_from_exception = Mock()
+        mock.description = Mock()
         fw = ReleasedBinary("1.1.1", "test")
         with patch("wb.device_manager.firmware_update.flash_fw", mock.flash_fw), patch(
             "wb.device_manager.firmware_update.download_wbfw", mock.download_wbfw
@@ -316,6 +317,7 @@ class TestRestoreFirmware(unittest.IsolatedAsyncioTestCase):
                 call.download_wbfw(downloader_mock, fw.endpoint),
                 call.flash_fw(mock, self.wbfw, mock),
                 call.set_error_from_exception(mock.flash_fw.side_effect),
+                call.set_poll(True),
             ]
             mock.assert_has_calls(expected_calls, False)
             self.assertEqual(len(mock.mock_calls) - len(mock.description.mock_calls), len(expected_calls))
@@ -366,6 +368,7 @@ class TestUpdateSoftware(unittest.IsolatedAsyncioTestCase):
         mock.set_progress = Mock()
         mock.set_poll = AsyncMock()
         mock.set_error_from_exception = Mock()
+        mock.description = Mock()
         mock.delete = Mock()
         fw = ReleasedBinary("1.1.1", "test")
         sw = SoftwareComponent(available=fw)
@@ -386,6 +389,7 @@ class TestUpdateSoftware(unittest.IsolatedAsyncioTestCase):
                 call.download_wbfw(downloader_mock, fw.endpoint),
                 call.flash_fw(mock, self.wbfw, mock),
                 call.set_error_from_exception(mock.flash_fw.side_effect),
+                call.set_poll(True),
             ]
             mock.assert_has_calls(expected_calls, False)
             self.assertEqual(len(mock.mock_calls) - len(mock.description.mock_calls), len(expected_calls))

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -435,7 +435,6 @@ async def update_software(
             download_wbfw(binary_downloader, software.available.endpoint),
             update_state_notifier,
         )
-        await serial_device.set_poll(True)  # resume device poll
     except (WBRemoteStorageError, SerialExceptionBase) as e:
         update_state_notifier.set_error_from_exception(e)
         logger.error(
@@ -449,6 +448,8 @@ async def update_software(
             e,
         )
         return False
+    finally:
+        await serial_device.set_poll(True)  # resume device poll
     logger.info(
         "%s (sn: %d, %s) %s update from %s to %s completed",
         device_model,
@@ -485,11 +486,12 @@ async def restore_firmware(
             download_wbfw(binary_downloader, firmware.endpoint),
             update_state_notifier,
         )
-        await serial_device.set_poll(True)  # resume device poll
     except (WBRemoteStorageError, SerialExceptionBase) as e:
         update_state_notifier.set_error_from_exception(e)
         logger.error("Firmware restore of %s failed: %s", serial_device.description, e)
         return
+    finally:
+        await serial_device.set_poll(True)  # resume device poll
     update_state_notifier.delete()
     logger.info("Firmware of device %s is restored to %s", serial_device.description, firmware.version)
 


### PR DESCRIPTION
В дополнение к PR https://github.com/wirenboard/wb-device-manager/pull/70 добавил включение опроса устройства в случае сбоя прошивки.
