### PR TITLE
Add missed dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.23.1) stable; urgency=medium
+
+  * Add missed dependency
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 09 Sep 2025 12:00:00 +0400
+
 wb-device-manager (1.23.0) stable; urgency=medium
 
   * Improve long timeouts handling during fast scan

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Replaces: python3-wb-device-manager
 Provides: python3-wb-device-manager
 Depends: ${python3:Depends},
          ${misc:Depends},
+         python3-packaging,
          python3-paho-mqtt,
          python3-wb-common (>= 2.1.0),
          python3-mqttrpc (>= 1.1.5),


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В булзае python3-packaging подтягивался как зависимость paho-socket, поэтому не замечали, а в трикси уже не ставим paho-socket и отсутствие python3-packaging выявилось.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


