### PR TITLE
Don't check new firmware for WB-MSW-LORA devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.23.2) stable; urgency=medium
+
+  * Don't check new firmware for WB-MSW-LORA devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 25 Sep 2025 17:31:49 +0500
+
 wb-device-manager (1.23.1) stable; urgency=medium
 
   * Add missed dependency

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -717,6 +717,10 @@ class FirmwareUpdater:
             logger.warning("Can't get firmware signature for %s: %s", serial_device.description, err)
             return res
 
+        # Can't update WB-MSW-LORA devices, so don't check new firmware
+        if signature in ["msw5GL", "msw3G419L"]:
+            return res
+
         try:
             res["available_fw"] = self._fw_info_reader.read_released_fw(signature).version
         except NoReleasedFwError as err:


### PR DESCRIPTION
We can't update firmware of WB-MSW-LORA devices properly and don't want to spend time for R&D, so just skip them

___________________________________
**Что происходит; кому и зачем нужно:**
Не ищем новые прошивки для Wb-MSW-LORA, т.к. не умеем их нормально загружать. Устройств сделано очень мало, и новые давно не выпускаются, тратить время на корректную реализацию обновления прошивки не хотим.

___________________________________
**Что поменялось для пользователей:**
В web-интерфейсе не будет информации о новых прошивках. Обновить из консоли всё ещё можно.
Оповещение в web-интерфейсе создавало ложные надежды, что всё пройжёт успешно, что совсем не так.
Теперь клиент будет обновлять прошивку только, если понимает, что делает.

___________________________________
**Как проверял/а:**


