### PR TITLE
Add protocol to firmware update status

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ MQTT RPC запрос `wb-device-manager/fw-update/GetFirmwareInfo/client_id` п
             // Адрес
             "slave_id": 100,
 
+            // Протокол обмена с устройством. Либо "modbus", либо "modbus-tcp".
+            "protocol": "modbus",
+
             // Процент завершения процесса обновления
             "progress": 50,
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.24.0) stable; urgency=medium
+
+  * Add protocol to firmware update status
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 26 Sep 2025 11:46:34 +0500
+
 wb-device-manager (1.23.1) stable; urgency=medium
 
   * Add missed dependency

--- a/tests/firmware_update_test.py
+++ b/tests/firmware_update_test.py
@@ -58,10 +58,18 @@ class PortTest(unittest.TestCase):
 
 class DeviceUpdateInfoTest(unittest.TestCase):
     def test_eq(self):
-        d1 = DeviceUpdateInfo(port=Port("test"), slave_id=1, to_version="1")
-        d2 = DeviceUpdateInfo(port=Port("test"), slave_id=1, to_version="1")
-        d3 = DeviceUpdateInfo(port=Port("test"), slave_id=2, to_version="1")
-        d4 = DeviceUpdateInfo(port=Port("test1"), slave_id=1, to_version="1")
+        d1 = DeviceUpdateInfo(
+            port=Port("test"), protocol=ModbusProtocol.MODBUS_RTU, slave_id=1, to_version="1"
+        )
+        d2 = DeviceUpdateInfo(
+            port=Port("test"), protocol=ModbusProtocol.MODBUS_RTU, slave_id=1, to_version="1"
+        )
+        d3 = DeviceUpdateInfo(
+            port=Port("test"), protocol=ModbusProtocol.MODBUS_RTU, slave_id=2, to_version="1"
+        )
+        d4 = DeviceUpdateInfo(
+            port=Port("test1"), protocol=ModbusProtocol.MODBUS_RTU, slave_id=1, to_version="1"
+        )
         self.assertEqual(d1, d2)
         self.assertNotEqual(d1, d3)
         self.assertNotEqual(d1, d4)

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -71,7 +71,12 @@ class DeviceUpdateInfo:  # pylint: disable=too-many-instance-attributes
     component_model: Optional[str] = None
 
     def __eq__(self, o):
-        return self.slave_id == o.slave_id and self.port == o.port and self.type == o.type
+        return (
+            self.slave_id == o.slave_id
+            and self.port == o.port
+            and self.type == o.type
+            and self.protocol == o.protocol
+        )
 
 
 class UpdateState:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил протокол в статус обновления прошивки. Это будет использоваться в homeui, для корректного отображения хода обновления. Подробнее [тут](https://wirenboard.youtrack.cloud/issue/SOFT-5942/Nekorrektno-otobrazhaetsya-hod-obnovleniya-proshivki)

___________________________________
**Что поменялось для пользователей:**
Ничего

___________________________________
**Как проверял/а:**
Делал несколько портов с одним адресом, но разными протоколами, и смотрел, что прогресс рисуется у нужных устройств

