### PR TITLE
Fix firmware update state publishing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.25.1) stable; urgency=medium
+
+  * Fix firmware update state publishing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 07 Oct 2025 17:56:44 +0500
+
 wb-device-manager (1.25.0) stable; urgency=medium
 
   * Add Fast Modbus scanning support for Modbus TCP

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -134,6 +134,7 @@ class UpdateState:
 def to_dict_for_json(device_update_info: DeviceUpdateInfo) -> dict:
     d = asdict(device_update_info)
     d["type"] = device_update_info.type.value
+    d["protocol"] = device_update_info.protocol.value
     return d
 
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
https://wirenboard.youtrack.cloud/issue/SOFT-6078/Ne-obnovlyayutsya-proshivki-ustrojstv-cherez-WebUI
При сериализации в JSON выпадала ошибка `TypeError: Object of type ModbusProtocol is not JSON serializable` и процесс останавливался.

___________________________________
**Что поменялось для пользователей:**
Прошивки обновляются

___________________________________
**Как проверял/а:**
Обновил прошивку

