### PR TITLE
Fix port configuration in scan results

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-device-manager (1.25.4) stable; urgency=medium
 
-  * 
+  * Fix port configuration in scan results
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 05 Feb 2026 10:36:46 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-device-manager (1.25.4) stable; urgency=medium
+
+  * 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 05 Feb 2026 10:36:46 +0500
+
 wb-device-manager (1.25.3) stable; urgency=medium
 
   * Fix dependencies and test warnings


### PR DESCRIPTION
wb-mqtt-serial can return incomplete port configuration for scanned device. Use current scanner config as device port config if scanning through serial port.

___________________________________
**Что происходит; кому и зачем нужно:**
Если на шине есть проблемы wb-mqtt-serial может прочитать не все настройки порта. Поэтому для сканирования через последовательный порт используем настройки самого порта. 

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


