### PR TITLE
Take released bootloader version from release-versions.yaml

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-device-manager (1.26.0) stable; urgency=medium
+
+  * Take the released bootloader version from boot/by-signature/release-versions.yaml
+    by the controller's release suite (testing/stable), mirroring firmwares; offer a
+    bootloader update when the released version is newer than the one on the device
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Tue, 30 Jun 2026 16:00:00 +0300
+
 wb-device-manager (1.25.5) stable; urgency=medium
 
   * Fix pylint

--- a/tests/firmware_update_test.py
+++ b/tests/firmware_update_test.py
@@ -26,7 +26,11 @@ from wb.device_manager.firmware_update import (
     update_software,
     write_fw_data_block,
 )
-from wb.device_manager.fw_downloader import ReleasedBinary
+from wb.device_manager.fw_downloader import (
+    NoReleasedFwError,
+    ReleasedBinary,
+    get_released_bootloader,
+)
 from wb.device_manager.mqtt_rpc import MQTTRPCErrorCode
 from wb.device_manager.serial_rpc import (
     WB_DEVICE_PARAMETERS,
@@ -37,6 +41,45 @@ from wb.device_manager.serial_rpc import (
     TcpConfig,
     WBModbusException,
 )
+
+
+class TestGetReleasedBootloader(unittest.TestCase):
+    BOOT_RELEASES_URL = "https://fw-releases.wirenboard.com/boot/by-signature/release-versions.yaml"
+
+    @staticmethod
+    def _downloader(yaml_text):
+        downloader = Mock()
+        downloader.read_text_file = Mock(return_value=yaml_text)
+        return downloader
+
+    def test_returns_released_bootloader_for_suite(self):
+        downloader = self._downloader(
+            "releases:\n"
+            "  sig_a:\n"
+            "    stable: boot/by-signature/sig_a/main/1.2.0.wbfw\n"
+            "    testing: boot/by-signature/sig_a/main/1.2.3.wbfw\n"
+        )
+        res = get_released_bootloader("sig_a", "testing", downloader)
+        self.assertEqual(res.version, "1.2.3")
+        self.assertEqual(
+            res.endpoint,
+            "https://fw-releases.wirenboard.com/boot/by-signature/sig_a/main/1.2.3.wbfw",
+        )
+        downloader.read_text_file.assert_called_once_with(self.BOOT_RELEASES_URL)
+
+    def test_raises_when_signature_absent(self):
+        downloader = self._downloader(
+            "releases:\n  other:\n    testing: boot/by-signature/other/main/1.0.0.wbfw\n"
+        )
+        with self.assertRaises(NoReleasedFwError):
+            get_released_bootloader("sig_b", "testing", downloader)
+
+    def test_raises_when_suite_absent(self):
+        downloader = self._downloader(
+            "releases:\n  sig_c:\n    stable: boot/by-signature/sig_c/main/1.0.0.wbfw\n"
+        )
+        with self.assertRaises(NoReleasedFwError):
+            get_released_bootloader("sig_c", "testing", downloader)
 
 
 class PortTest(unittest.TestCase):
@@ -145,6 +188,29 @@ class TestGetFirmwareInfo(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(count_of_readings_func(count_of_readings))
         self.assertEqual(components, result)
+
+    async def test_read_bootloader_info_without_released_bootloader(self):
+        # No released bootloader for the signature/suite: read_bootloader_info must swallow
+        # NoReleasedFwError and return available=None instead of propagating it.
+        def read(param_config: ParameterConfig):
+            if param_config == WB_DEVICE_PARAMETERS["reboot_to_bootloader_preserve_port_settings"]:
+                return 0
+            return "1.2.3"
+
+        serial_device = AsyncMock()
+        serial_device.read = AsyncMock()
+        serial_device.read.side_effect = read
+
+        with patch("wb.device_manager.firmware_update.parse_releases", Mock()), patch(
+            "wb.device_manager.firmware_update.get_released_bootloader",
+            side_effect=NoReleasedFwError("no released bootloader"),
+        ):
+            reader = FirmwareInfoReader(None)
+            res = await reader.read_bootloader_info(serial_device, "sig")
+
+        self.assertIsInstance(res, BootloaderInfo)
+        self.assertEqual(res.current_version, "1.2.3")
+        self.assertIsNone(res.available)
 
     async def test_successful_read(self):
         reader_mock = AsyncMock()

--- a/wb/device_manager/firmware_update.py
+++ b/wb/device_manager/firmware_update.py
@@ -20,7 +20,7 @@ from .fw_downloader import (
     ReleasedBinary,
     RemoteFileDownloadingError,
     WBRemoteStorageError,
-    get_latest_bootloader,
+    get_released_bootloader,
     get_released_fw,
 )
 from .mqtt_rpc import MQTTRPCAlreadyProcessingException, MQTTRPCErrorCode
@@ -244,8 +244,8 @@ class FirmwareInfoReader:
             res.current_version = cast(
                 str, await serial_device.read(WB_DEVICE_PARAMETERS["bootloader_version"])
             )
-            res.available = get_latest_bootloader(fw_signature, self._downloader)
-        except (SerialExceptionBase, WBRemoteStorageError) as err:
+            res.available = get_released_bootloader(fw_signature, self._release, self._downloader)
+        except (SerialExceptionBase, WBRemoteStorageError, NoReleasedFwError) as err:
             logger.debug("Can't get bootloader information for %s: %s", serial_device.description, err)
         return res
 
@@ -462,6 +462,17 @@ async def update_software(
     Returns:
         bool: True if the update was successful, False otherwise.
     """
+
+    if software.available is None:
+        # No released firmware/bootloader for this signature/suite. Normally the UI won't offer
+        # the update (has_update is False), but guard the direct-RPC path against an opaque crash.
+        logger.error(
+            "No released %s for %s, nothing to flash", software.type.value, serial_device.description
+        )
+        update_state_notifier.set_error_from_exception(
+            NoReleasedFwError(f"No released {software.type.value} for the device")
+        )
+        return False
 
     update_state_notifier.set_progress(0)
     device_model = ""

--- a/wb/device_manager/fw_downloader.py
+++ b/wb/device_manager/fw_downloader.py
@@ -84,58 +84,64 @@ class BinaryDownloader:
             raise RemoteFileDownloadingError(f"Failed to download {url}: {err}") from err
 
 
+def _get_released_binary(
+    releases_url: str, fw_signature: str, release_suite: str, binary_downloader: BinaryDownloader
+) -> ReleasedBinary:
+    """
+    Looks up the released firmware/bootloader for a signature and suite in a
+    by-signature/release-versions.yaml index (keyed by signature, then suite).
+
+    Args:
+        releases_url (str): URL of the release-versions.yaml index.
+        fw_signature (str): The firmware signature.
+        release_suite (str): The release suite (e.g. "stable"/"testing").
+        binary_downloader (BinaryDownloader): The binary downloader object.
+
+    Returns:
+        ReleasedBinary: The released binary with its version and endpoint.
+
+    Raises:
+        NoReleasedFwError: If nothing is released for the signature/suite.
+    """
+    logger.debug("Looking to %s (suite: %s)", releases_url, release_suite)
+    try:
+        contents = binary_downloader.read_text_file(releases_url)
+        endpoint = yaml.safe_load(contents).get("releases", {}).get(fw_signature, {}).get(release_suite)
+        if endpoint:
+            endpoint = f"{FW_RELEASES_BASE_URL}/{endpoint}"
+            version = parse_fw_version(endpoint)
+            logger.debug(
+                "Released binary for %s on release %s: %s (endpoint: %s)",
+                fw_signature,
+                release_suite,
+                version,
+                endpoint,
+            )
+            return ReleasedBinary(version, endpoint)
+    except WBRemoteStorageError as e:
+        logger.warning('No released binary for "%s" in "%s": %s', fw_signature, releases_url, e)
+    except VersionParsingError as e:
+        logger.exception(e)
+    except yaml.YAMLError as e:
+        logger.warning("Failed to parse YAML from %s: %s", releases_url, e)
+    raise NoReleasedFwError(f"Released binary not found for {fw_signature}, release: {release_suite}")
+
+
 # Cache information about released firmware for 10 minutes
 @ttl_lru_cache(seconds_to_live=600, maxsize=100)
 def get_released_fw(
     fw_signature: str, release_suite: str, binary_downloader: BinaryDownloader
 ) -> ReleasedBinary:
-    """
-    Retrieves the released firmware for a given firmware signature and release suite.
-
-    Args:
-        fw_signature (str): The firmware signature.
-        release_suite (str): The release suite.
-        binary_downloader (BinaryDownloader): The binary downloader object.
-
-    Returns:
-        ReleasedBinary: The released binary object containing the firmware version and endpoint.
-
-    Raises:
-        NoReleasedFwError: If the firmware is not found.
-    """
-
+    """Released firmware for a signature and suite (fw/by-signature/release-versions.yaml)."""
     url = f"{FW_RELEASES_BASE_URL}/fw/by-signature/release-versions.yaml"
-    logger.debug("Looking to %s (suite: %s)", url, release_suite)
-    try:
-        contents = binary_downloader.read_text_file(url)
-        fw_endpoint = yaml.safe_load(contents).get("releases", {}).get(fw_signature, {}).get(release_suite)
-        if fw_endpoint:
-            fw_endpoint = f"{FW_RELEASES_BASE_URL}/{fw_endpoint}"
-            fw_version = parse_fw_version(fw_endpoint)
-            logger.debug(
-                "FW version for %s on release %s: %s (endpoint: %s)",
-                fw_signature,
-                release_suite,
-                fw_version,
-                fw_endpoint,
-            )
-            return ReleasedBinary(fw_version, fw_endpoint)
-    except WBRemoteStorageError as e:
-        logger.warning('No released fw for "%s" in "%s": %s', fw_signature, url, e)
-    except VersionParsingError as e:
-        logger.exception(e)
-    except yaml.YAMLError as e:
-        message = f"Failed to parse YAML from {url}: {e}"
-        logger.warning(message)
-    raise NoReleasedFwError(f"Released FW not found for {fw_signature}, release: {release_suite}")
+    return _get_released_binary(url, fw_signature, release_suite, binary_downloader)
 
 
 # Bootloader changes rarely, so we can cache it for a longer time
 @ttl_lru_cache(seconds_to_live=1800, maxsize=100)
-def get_latest_bootloader(fw_signature: str, binary_downloader: BinaryDownloader) -> ReleasedBinary:
-    bootloader_url_prefix = f"{FW_RELEASES_BASE_URL}/bootloader/by-signature/{fw_signature}/main"
-    bootloader_latest_txt_url = f"{bootloader_url_prefix}/latest.txt"
-    version = binary_downloader.read_text_file(bootloader_latest_txt_url)
-    endpoint = f"{bootloader_url_prefix}/{version}.wbfw"
-    logger.debug("Bootloader for %s: %s (endpoint: %s)", fw_signature, version, endpoint)
-    return ReleasedBinary(version, endpoint)
+def get_released_bootloader(
+    fw_signature: str, release_suite: str, binary_downloader: BinaryDownloader
+) -> ReleasedBinary:
+    """Released bootloader for a signature and suite (boot/by-signature/release-versions.yaml)."""
+    url = f"{FW_RELEASES_BASE_URL}/boot/by-signature/release-versions.yaml"
+    return _get_released_binary(url, fw_signature, release_suite, binary_downloader)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

wb-device-manager теперь берёт актуальную версию загрузчика из `boot/by-signature/release-versions.yaml`, выбирая её по сигнатуре устройства и релизу контроллера (testing/stable) — ровно так же, как это уже работает для прошивок. Раньше версия загрузчика читалась из `bootloader/.../latest.txt`.

___________________________________
**Что поменялось для пользователей:**

- На странице обновления устройств обновление загрузчика предлагается, когда версия из релиза новее установленной на устройстве — поведение полностью как у прошивок. **Только обновление, без даунгрейда** (в отличие от wb-mcu-fw-updater).
- Доступная версия загрузчика и флаг «есть обновление» теперь зависят от релиза контроллера (testing/stable).
- Если для сигнатуры/релиза загрузчик не опубликован — обновление просто не предлагается (как и раньше при отсутствии `latest.txt`).

___________________________________
**Как проверял/а:**

- Юнит-тесты: 56/56 проходят на контроллере (wb-2606, Python 3.9), включая новые тесты `get_released_bootloader` и тест на то, что `read_bootloader_info` возвращает `available=None` без исключения, когда релиза нет.
- `black` (line-length 110) + `isort` (profile black) — чисто; `pylint` — без новых замечаний к изменённым строкам.
- На реальном устройстве **wb-mai6-15**, контроллер на testing новый код сообщает `bootloader 1.5.5 → available_bootloader 1.5.7` (endpoint `.../boot/by-signature/wb-mai6-15/main/1.5.7.wbfw`), `bootloader_has_update: True` — совпадает с тем, что показывает WebUI.
